### PR TITLE
Sprint 0 - Add CI GitHub Actions for backend

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -28,6 +28,4 @@ jobs:
 
       - name: Run tests
         working-directory: backend
-        run: |
-          chmod +x mvnw
-          ./mvnw test
+        run: mvn -B test


### PR DESCRIPTION
## Contexte
Mise en place de la CI pour sécuriser le workflow dès le Sprint 0.

## Ce qui a été fait
- Ajout d’un workflow GitHub Actions pour le backend
- Exécution de `./mvnw test` à chaque PR et push sur main
- Configuration Java 17 avec cache Maven

## Ce qui n’est pas encore fait
- CI pour le frontend (prévu dans un prochain sprint)
- Étapes de build Docker

## Issue liée
Closes #<5>