### PR TITLE
Sprint 2 : Update Parcel Status

### DIFF
--- a/backend/src/main/java/com/relayflow/backend/api/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/relayflow/backend/api/ApiExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.relayflow.backend.api;
 
 import com.relayflow.backend.service.DuplicateReferenceException;
+import com.relayflow.backend.service.InvalidStatusTransitionException;
 import com.relayflow.backend.service.ParcelNotFoundException;
 import org.springframework.beans.factory.parsing.Problem;
 import org.springframework.http.HttpStatus;
@@ -8,6 +9,8 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
 
 @RestControllerAdvice
 public class ApiExceptionHandler {
@@ -22,5 +25,10 @@ public class ApiExceptionHandler {
     @ResponseStatus(HttpStatus.CONFLICT)
     public ProblemDetail conflict(DuplicateReferenceException ex) {
         return ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, ex.getMessage());
+    }
+    @ExceptionHandler(InvalidStatusTransitionException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> handleInvalidStatus(InvalidStatusTransitionException ex) {
+        return Map.of("error", ex.getMessage());
     }
 }

--- a/backend/src/main/java/com/relayflow/backend/api/ParcelController.java
+++ b/backend/src/main/java/com/relayflow/backend/api/ParcelController.java
@@ -3,6 +3,7 @@ package com.relayflow.backend.api;
 
 import com.relayflow.backend.api.dto.CreateParcelRequest;
 import com.relayflow.backend.api.dto.ParcelResponse;
+import com.relayflow.backend.api.dto.UpdateParcelStatusRequest;
 import com.relayflow.backend.domain.Parcel;
 import com.relayflow.backend.repository.ParcelRepository;
 import com.relayflow.backend.service.ParcelService;
@@ -18,6 +19,7 @@ import java.util.UUID;
 public class ParcelController {
     private final ParcelService parcelService;
     public ParcelController(ParcelService parcelService) {
+
         this.parcelService = parcelService;
     }
     @PostMapping
@@ -35,5 +37,12 @@ public class ParcelController {
 
         return parcelService.getByReference(reference);
     }
+    @PatchMapping("/{reference}/status")
+    public ParcelResponse updateStatus(
+            @PathVariable String reference,
+            @RequestBody UpdateParcelStatusRequest request
+    ) {
+        return parcelService.changeStatus(reference, request.status());
 
+    }
 }

--- a/backend/src/main/java/com/relayflow/backend/api/dto/UpdateParcelStatusRequest.java
+++ b/backend/src/main/java/com/relayflow/backend/api/dto/UpdateParcelStatusRequest.java
@@ -1,0 +1,7 @@
+package com.relayflow.backend.api.dto;
+
+import com.relayflow.backend.domain.ParcelStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateParcelStatusRequest( @NotNull ParcelStatus status) {
+}

--- a/backend/src/main/java/com/relayflow/backend/domain/Parcel.java
+++ b/backend/src/main/java/com/relayflow/backend/domain/Parcel.java
@@ -1,5 +1,6 @@
 package com.relayflow.backend.domain;
 
+import com.relayflow.backend.service.InvalidStatusTransitionException;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.UUID;
@@ -49,6 +50,25 @@ public class Parcel {
         p.createdAt = Instant.now();
         p.updatedAt = Instant.now();
         return p;
+    }
+    public void changeStatus (ParcelStatus newStatus) {
+        if(this.status==ParcelStatus.DELIVERED) {
+            throw new InvalidStatusTransitionException(this.status, newStatus);
+        }
+      if(!isNextStatus(newStatus)) {
+          throw new InvalidStatusTransitionException(this.status, newStatus);
+      }
+      this.status = newStatus;
+      this.updatedAt = Instant.now();
+    }
+    private boolean isNextStatus(ParcelStatus newStatus) {
+        return switch (this.status){
+            case CREATED -> newStatus.equals(ParcelStatus.IN_TRANSIT);
+            case IN_TRANSIT -> newStatus.equals(ParcelStatus.ARRIVED_AT_RELAY);
+            case ARRIVED_AT_RELAY -> newStatus.equals(ParcelStatus.DELIVERED);
+            case DELIVERED -> false;
+
+        };
     }
 }
 

--- a/backend/src/main/java/com/relayflow/backend/service/InvalidStatusTransitionException.java
+++ b/backend/src/main/java/com/relayflow/backend/service/InvalidStatusTransitionException.java
@@ -1,0 +1,9 @@
+package com.relayflow.backend.service;
+
+import com.relayflow.backend.domain.ParcelStatus;
+
+public class InvalidStatusTransitionException extends RuntimeException{
+    public InvalidStatusTransitionException(ParcelStatus from, ParcelStatus to) {
+        super("Transition invalide de " + from + " to " + to);
+    }
+}

--- a/backend/src/main/java/com/relayflow/backend/service/ParcelService.java
+++ b/backend/src/main/java/com/relayflow/backend/service/ParcelService.java
@@ -3,6 +3,7 @@ package com.relayflow.backend.service;
 import com.relayflow.backend.api.dto.CreateParcelRequest;
 import com.relayflow.backend.api.dto.ParcelResponse;
 import com.relayflow.backend.domain.Parcel;
+import com.relayflow.backend.domain.ParcelStatus;
 import com.relayflow.backend.repository.ParcelRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +18,7 @@ public class ParcelService {
         this.parcelRepository = parcelRepository;
     }
 
-
-
-    /*public ParcelResponse getById(UUID id) {
+ /*public ParcelResponse getById(UUID id) {
         Parcel parcel = parcelRepository.findById(id).orElseThrow(()-> new ParcelNotFoundException(id));
         return toResponse(parcel);
     }*/
@@ -51,5 +50,12 @@ public class ParcelService {
 
 
     }
-
+@Transactional
+public ParcelResponse changeStatus(String reference, ParcelStatus status)
+{
+    Parcel parcel = parcelRepository.findByReference(reference).orElseThrow(()-> new ParcelNotFoundException(reference));
+    parcel.changeStatus(status);
+   // return parcelRepository.save(parcel); hibernate va flusher tout seul parce qu'on a @transactional
+    return toResponse(parcel) ;
+}
 }


### PR DESCRIPTION
Cette PR ajoute la possibilité de mettre à jour le statut d'un colis à l'aide d'une machine à états métier.

- Ajout du point de terminaison PATCH /api/parcels/{reference}/status
- Implémentation des règles métier au sein de l'entité Parcel
- Empêche les transitions d'état invalides
- Ajout d'une gestion appropriée des erreurs (404, 400)
- Ajout du DTO UpdateParcelStatusRequest
- Utilisation d'une couche de service transactionnelle

Testé avec Postman avec des transitions valides et invalides.