### PR TITLE
Sprint 2-Issue 11 -UI : Boutons de changement de statut sur la page détail colis

### DIFF
--- a/frontend/relayflow-frontend/package.json
+++ b/frontend/relayflow-frontend/package.json
@@ -35,5 +35,5 @@
     "karma-jasmine-html-reporter": "~2.1.0",
     "typescript": "~5.5.2"
   }
-  
+
 }

--- a/frontend/relayflow-frontend/src/app/api/parcel.model.ts
+++ b/frontend/relayflow-frontend/src/app/api/parcel.model.ts
@@ -5,7 +5,7 @@ export interface Parcel {
     reference : string ;
     status  :ParcelStatus;
     createdAt : string ;
-    updateAt : string;
+    updatedAt : string;
 }
 export interface createParcelRequet {
 reference : string ;

--- a/frontend/relayflow-frontend/src/app/api/parcel.service.ts
+++ b/frontend/relayflow-frontend/src/app/api/parcel.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
-import { createParcelRequet, Parcel } from "./parcel.model";
+import { createParcelRequet, Parcel, ParcelStatus } from "./parcel.model";
 
 @Injectable({providedIn: "root"})
 export class ParcelService {
@@ -12,7 +12,10 @@ constructor(private http :HttpClient) {
 create (req:createParcelRequet) : Observable<Parcel> {
     return this.http.post<Parcel>(this.baseUrl , req);
 }
-getByReference(reference :String) :Observable<Parcel> {
-    return this.http.get<Parcel>(this.baseUrl+`/by-reference/${reference}`)
+getByReference(reference :string) :Observable<Parcel> {
+    return this.http.get<Parcel>(`${this.baseUrl}/by-reference/${encodeURIComponent(reference)}`);
+}
+updateStatus(reference : string , status : ParcelStatus) {
+return this.http.patch<Parcel> (`${this.baseUrl}/${encodeURIComponent(reference)}/status` , {status})
 }
 }

--- a/frontend/relayflow-frontend/src/app/parcels/parcel-detail/parcel-detail.component.html
+++ b/frontend/relayflow-frontend/src/app/parcels/parcel-detail/parcel-detail.component.html
@@ -1,26 +1,39 @@
 <div style="max-width: 520px; margin: 40px auto; padding: 16px;">
   <a routerLink="/parcels/new">← Retour</a>
 
-  <h2 style="margin-top: 16px;">Détail colis</h2>
+  <ng-container *ngIf="vm$ | async as vm">
+    <p *ngIf="vm.state === 'loading'">Chargement…</p>
 
-  <ng-container *ngIf="vm$ | async as vm; else loading">
-    <div *ngIf="vm.state === 'notfound'">
-      <p>Colis introuvable.</p>
-    </div>
+    <p *ngIf="vm.state === 'error'" style="color:#b00020;">
+      {{ vm.message }}
+    </p>
 
-    <div *ngIf="vm.state === 'error'">
-      <p style="color: #b00020;">{{ vm.message }}</p>
-    </div>
+    <p *ngIf="vm.state === 'notfound'" style="color:#b00020;">
+      Colis introuvable.
+    </p>
 
     <div *ngIf="vm.state === 'ready'">
+      <h2>Détail colis</h2>
+
       <p><b>Référence :</b> {{ vm.parcel.reference }}</p>
       <p><b>Statut :</b> {{ vm.parcel.status }}</p>
-      <p><b>Créé le :</b> {{ vm.parcel.createdAt | date:'medium' }}</p>
-      <p><b>Mis à jour le :</b> {{ vm.parcel.updateAt | date:'medium' }}</p>
+      <p><b>Créé le :</b> {{ vm.parcel.createdAt ? (vm.parcel.createdAt | date:'medium') : '-' }}</p>
+      <p><b>Mis à jour le :</b> {{ vm.parcel.updatedAt ? (vm.parcel.updatedAt | date:'medium') : '-' }}</p>
+
+      <div style="margin-top: 16px;">
+        <ng-container *ngIf="nextAction(vm.parcel.status) as action">
+          <button
+            (click)="updateStatus(vm.parcel.reference, action.next)"
+            [disabled]="vm.isUpdating"
+          >
+            {{ vm.isUpdating ? 'Mise à jour…' : action.label }}
+          </button>
+        </ng-container>
+
+        <p *ngIf="vm.updateError" style="color:#b00020; margin-top: 8px;">
+          {{ vm.updateError }}
+        </p>
+      </div>
     </div>
   </ng-container>
-
-  <ng-template #loading>
-    <p>Chargement...</p>
-  </ng-template>
 </div>

--- a/frontend/relayflow-frontend/src/app/parcels/parcel-detail/parcel-detail.component.ts
+++ b/frontend/relayflow-frontend/src/app/parcels/parcel-detail/parcel-detail.component.ts
@@ -1,14 +1,15 @@
 import { Component, inject } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ParcelService } from '../../api/parcel.service';
-import { catchError, map, of, switchMap } from 'rxjs';
-import { Parcel } from '../../api/parcel.model';
+import { BehaviorSubject, catchError, combineLatest, map, of, switchMap } from 'rxjs';
+import { Parcel, ParcelStatus } from '../../api/parcel.model';
 import { AsyncPipe, DatePipe, NgIf } from '@angular/common';
 
+//ViewState = le contrat / la structure de données , Ce n’est pas une variable,Ce n’est pas un observable :juste un type TypeScript,décrit toutes les formes possibles de l’état de la page
 type ViewState = |{state :'loading'}
 |{state :'error' ; message : string}
 |{state :'notfound'}
-|{state :'ready'; parcel :Parcel}
+|{state :'ready'; parcel :Parcel ,isUpdating : boolean ; updateError ?:string}
 
 @Component({
   selector: 'app-parcel-detail',
@@ -20,7 +21,33 @@ type ViewState = |{state :'loading'}
 export class ParcelDetailComponent {
 private route =inject(ActivatedRoute);
 private parcelService = inject(ParcelService);
-vm$=this.route.paramMap.pipe(map(pm=>pm.get('reference')),
+private updating$ = new BehaviorSubject<boolean>(false); //état de mise à jour
+private updateError$ = new BehaviorSubject <String | null >(null);//erreur éventuelle
+//le choix de behaviviorsubject
+// behaviviorsubject parce que ça devient réactif qui peut être observée , émettre des nouvelles
+//  valeurs ou bien garder la dernière  valeur courante (si on choisit subject : le subject n'a pas de valeur initiale mais behaviorsubject a tujours une valeur acttuelle)
+//avant vm$ représente est l'unique état principalede la page 
+//  il émettatit directement les loading / error / notfound / ready parce 
+// que c'est un observable viewstate maintenant on change l'architecture :
+//reference$ : Observable<string | null> (juste la valeur d’URL) 
+// // le choix d'observable car La valeur reference peut changer sans que le composant soit détruit
+//parcel$ : Observable<ViewState> (loading/error/notfound/ready)
+//updating$ : Observable<boolean> (état “je suis en train de PATCH”)
+//updateError$ : Observable<string | null> (erreur du PATCH)
+//vm$ :un observable qui émet un tableau avec les 3 dernières valeurs :
+// en d'autre termes Je construis un ViewModel unique à partir 
+// de 3 sources d’état réactives: (État du chargement du colis , État de mise à jour en cours ,État d’erreur de mise à jour en utilisant combinelast
+// À chaque changement, l’écran se met à jour automatiquement.: autrement : écran = combine(
+  //étatDuColis,
+  //estEnTrainDeMettreAJour,
+  //erreurDeMiseAJour
+//).map(les3États => construireUnObjetPourLUI)
+//Reactive ViewModel Composition C’est exactement ce qu’on fait en Angular moderne / React / Vue
+//vm$l’état réel et vivant de la page
+//pour info combinelast utilise un tableau parce rxjs émet les valeurs sous forme un tableau
+
+private reference$=this.route.paramMap.pipe(map(pm=>pm.get('reference')),);
+/*vm$=this.route.paramMap.pipe(map(pm=>pm.get('reference')),
 switchMap (reference=>{
   if(!reference) return of<ViewState>({state :'error', message : 'reference manquant dans l URL'});
   return this.parcelService.getByReference (reference).pipe(
@@ -31,6 +58,60 @@ return of<ViewState>({state :'error', message : 'erreur lors du chargement du co
 })
 );
 }),
+);*/
+private parcel$ =this.reference$.pipe(switchMap(reference=>{
+  if(!reference) return of<ViewState>({state : 'error' , message : 'reference manquante dans l URL'});
+return this.parcelService.getByReference(reference).pipe(
+  map(parcel=>({state : 'ready' , parcel , isUpdating :false} as ViewState)),
+  catchError(err=>{
+    if(err?.status===404) return of <ViewState>({state : 'notfound'});
+    return of <ViewState>({state : 'error' , message :'Erreur lors du chargement du colis'}) ;
+  })
 );
-
+})
+);
+//{ ...vm } = copie de l’objet : si vm est ts : {state : 'ready' , parcel : {...}} Alors{..vm} donne : ts {state : 'ready' , parcel : {...}}
+vm$= combineLatest([this.parcel$ ,this.updating$ , this.updateError$ ]).pipe(map(([vm,isUpdating , updateError])=>{
+  if(vm.state !== 'ready') return vm;
+  return { ...vm , isUpdating, updateError :updateError ?? undefined} as ViewState ;
 }
+)) ;
+nextAction(status : ParcelStatus) : {label : String ; next : ParcelStatus} | null {
+  switch(status){
+    case 'CREATED' :
+      return {label : 'Expédier' , next : 'IN_TRANSIT'};
+      case 'IN_TRANSIT' :
+        return {label : 'Arrivé au relais' , next : 'ARRIVED_AT_RELAY'}
+        case 'ARRIVED_AT_RELAY' :
+          return {label : 'Livré' , next : 'DELIVERED'};
+          case 'DELIVERED' :
+            return null;
+  }
+}
+updateStatus (reference : string , next : ParcelStatus){
+  this.updateError$.next(null);
+  this.updating$.next(true);
+  this.parcelService.updateStatus (reference , next).subscribe({
+    //// petit hack simple : on force un reload via navigation ou on peut mieux faire avec refresh stream
+        // Ici : on recharge la page en relançant le fetch (re-souscription) en resetant updating.
+        next: () => {
+          this.updating$.next(false);
+          // Pour refléter immédiatement sans complexifier, tu peux aussi faire un "soft reload" :
+        // => le plus simple est de rafraîchir en rechargant la route (si tu veux je te donne la version propre).
+        location.reload();
+        },
+        error: (err)=> {
+          this.updating$.next(false);
+          if(err?.status===400){
+            this.updateError$.next(err?.error?.message?? 'Transition invalide');
+          }
+          else if(err?.status===404) {
+            this.updateError$.next('Colis introuvable');
+          }else {
+            this.updateError$.next('Erreur lors de la mise à jour du statut');
+          }
+        }
+  });
+}
+}
+


### PR DESCRIPTION
### Objectif
Ajouter sur la page Détail colis des actions utilisateur permettant de changer le statut d’un colis

### Affichage conditionnel des actions
Selon parcel.status :
CREATED → bouton Expédier
IN_TRANSIT → Arrivé au relais
ARRIVED_AT_RELAY → Livré
DELIVERED → aucun bouton
->Un seul bouton est visible à la fois.

### Modifications techniques:
-ParcelDetailComponent
-ParcelService (méthode updateStatus)
-Ajout combineLatest pour gérer l’état complet de la vue
-Gestion loading / error / ready

### Tests réalisés
Affichage correct du bouton selon le statut
PATCH appelé correctement
Bouton désactivé pendant la requête
Mise à jour du statut après succès
Message d’erreur si 4xx/5xx
Aucun bouton quand DELIVERED