### PR TITLE
Sprint2-issue13-test_unit_interation_backend

### DIFF
--- a/backend/src/test/java/com/relayflow/backend/api/ParcelControllerIT.java
+++ b/backend/src/test/java/com/relayflow/backend/api/ParcelControllerIT.java
@@ -1,0 +1,109 @@
+package com.relayflow.backend.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.relayflow.backend.api.dto.UpdateParcelStatusRequest;
+import com.relayflow.backend.domain.Parcel;
+import com.relayflow.backend.domain.ParcelStatus;
+import com.relayflow.backend.repository.ParcelRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+//Ici on lance Spring mais pas un vrai serveur : MockMvc.
+//On va mocker la DB via @MockBean ParcelRepositor
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ParcelControllerIT {
+    @Autowired
+    MockMvc mvc ;
+    //ici on n'a pas mockeé le service:
+    //ici le but de notre test d'integretion est le test d'integration API dans notre cas et non pas on teste uniquement le controller
+    //pour info deux types de test différents
+    //1-test unitaire controller (isolé)  on mock le service  controller->mock service
+    //2-Test d’intégration API (ce qu’on fait ici) : on teste Controller + Service + logique métie
+    //controller-service->mock repository
+    //si je mcoke le service dans notre cas , o ne teste plus les régles métier, les exceptions , les transititos , le service loic
+    //je teste ainsi seulement controller appelle service  ça sera trop faible comme test
+    //donc test unitaire controller ->@WebMvcTest(Controller.class) @Mockbean Service : testse seulement routing+mapping JSON
+    //et pour test integration api : @SpringBootTest @Mockbean repo  but tester controller+service+domain ensemble
+     @MockitoBean  ParcelRepository repo ;
+
+    @Autowired
+    ObjectMapper om;
+    //ObjectMapper = cnvertisseur Java <-> JSON
+    //elle sert à java ->Json String json = objectMapper.writeValueAsString(obj)
+    //JSON ->Java
+    //Parcel p = ojectMapper.readValue(jsonParcel.class)
+    //pk spring l'a déjà : dans mon pom.xml spring boot starter web ce starter invlut Jackson automatiquement , Spring créé un ObjectMapper déjà configuré
+    //donc je peux l'injecter directement
+    //dans les test api , on doit envoyer du json
+    //sans ObjecttMapper je devrais ecrire "{\"status\":\"IN_TRANSIT\"}":horrible
+    //avec ObjectMapper  om.writeValueAsString(dto) propre , sur , automatique
+
+@Test
+    void getByReference_should_return_200() throws Exception {
+    Parcel p = Parcel.create("REF-017");
+    when(repo.findByReference("REF-017")).thenReturn(Optional.of(p));
+     mvc.perform(get("/api/parcels/by-reference/REF-017"))
+             .andExpect(status().isOk()).andExpect(jsonPath("$.reference").value("REF-017"))
+             .andExpect(jsonPath("$.status").value("CREATED"));
+
+}
+@Test
+    void getByReference_should_return_404() throws Exception {
+    when (repo.findByReference("REF-X")).thenReturn(Optional.empty());
+    mvc.perform(get("/api/parcels/by-reference/REF-X"))
+            .andExpect(status().isNotFound());
+
+}
+
+@Test
+    void patchStatus_should_return_200_when_is_valid() throws Exception {
+    Parcel p = Parcel.create("REF-018");
+    when(repo.findByReference("REF-018")).thenReturn(Optional.of(p));
+    String body = om.writeValueAsString(new UpdateParcelStatusRequest(ParcelStatus.IN_TRANSIT));
+mvc.perform(patch("/api/parcels/REF-018/status")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(body))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("IN_TRANSIT"));
+
+}
+
+@Test
+    void patchStatus_should_return_400_when_invalid_transition() throws Exception {
+    Parcel p = Parcel.create("REF-019");//CREATED
+    when(repo.findByReference("REF-019")).thenReturn(Optional.of(p));
+    //invalid : CREATED ->DELIVERED
+    String body = om.writeValueAsString(new UpdateParcelStatusRequest(ParcelStatus.DELIVERED));
+    mvc.perform(patch("/api/parcels/REF-019/status")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(body))
+            .andExpect(status().isBadRequest());
+
+}
+    @Test
+    void patchStatus_should_return_404_when_not_found() throws Exception {
+
+        when(repo.findByReference("REF-020")).thenReturn(Optional.empty());
+
+        String body = om.writeValueAsString(new UpdateParcelStatusRequest(ParcelStatus.IN_TRANSIT));
+        mvc.perform(patch("/api/parcels/REF-020/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isNotFound());
+
+}
+}

--- a/backend/src/test/java/com/relayflow/backend/domain/ParcelDomainTest.java
+++ b/backend/src/test/java/com/relayflow/backend/domain/ParcelDomainTest.java
@@ -1,0 +1,55 @@
+package com.relayflow.backend.domain;
+
+import com.relayflow.backend.service.InvalidStatusTransitionException;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+//Ce test n’utilise ni Spring ni DB. Il valide juste ton métier
+public class ParcelDomainTest {
+    @Test
+    void create_should_initialize_defaults(){
+        Parcel p= Parcel.create("REF-006");
+        assertNotNull(p.getCreatedAt());
+        assertNotNull(p.getUpdatedAt());
+        assertEquals(ParcelStatus.CREATED,p.getStatus());
+        assertEquals("REF-006",p.getReference());
+    }
+    @Test
+    void chaneStatus_should_allow_CREATED_to_IN_TRANSIT(){
+        Parcel p= Parcel.create("REF-007");
+        Instant before=p.getUpdatedAt();
+        p.changeStatus(ParcelStatus.IN_TRANSIT);
+        assertEquals(ParcelStatus.IN_TRANSIT,p.getStatus());
+        assertTrue(!p.getUpdatedAt().isBefore(before));    }
+    @Test
+    void chaneStatus_should_allow_IN_TRANSIT_toARRIVED_at_RELAY() {
+        Parcel p = Parcel.create("REF-008");
+        p.changeStatus(ParcelStatus.IN_TRANSIT);
+        p.changeStatus(ParcelStatus.ARRIVED_AT_RELAY);
+        assertEquals(ParcelStatus.ARRIVED_AT_RELAY, p.getStatus());
+    }
+
+    @Test
+    void chaneStatus_should_allow_ARRIVED_at_RELAY_to_DELIVERED() {
+        Parcel p = Parcel.create("REF-009");
+        p.changeStatus(ParcelStatus.IN_TRANSIT);
+        p.changeStatus(ParcelStatus.ARRIVED_AT_RELAY);
+        p.changeStatus(ParcelStatus.DELIVERED);
+        assertEquals(ParcelStatus.DELIVERED, p.getStatus());
+    }
+@Test
+    void changeStatus_should_reject_invalid_transition(){
+        Parcel p= Parcel.create("REF-010");
+        assertThrows(InvalidStatusTransitionException.class,()->p.changeStatus(ParcelStatus.DELIVERED));
+}
+@Test
+    void changeStatus_should_reject_any_transition_from_DELIVERED(){
+        Parcel p= Parcel.create("REF-011");
+        p.changeStatus(ParcelStatus.IN_TRANSIT);
+        p.changeStatus(ParcelStatus.ARRIVED_AT_RELAY);
+        p.changeStatus(ParcelStatus.DELIVERED);
+        assertThrows(InvalidStatusTransitionException.class,()->p.changeStatus(ParcelStatus.IN_TRANSIT));
+}
+    }

--- a/backend/src/test/java/com/relayflow/backend/service/ParcelServiceTest.java
+++ b/backend/src/test/java/com/relayflow/backend/service/ParcelServiceTest.java
@@ -1,0 +1,77 @@
+package com.relayflow.backend.service;
+
+import com.relayflow.backend.api.dto.CreateParcelRequest;
+import com.relayflow.backend.api.dto.ParcelResponse;
+import com.relayflow.backend.domain.Parcel;
+import com.relayflow.backend.domain.ParcelStatus;
+import com.relayflow.backend.repository.ParcelRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+//Ici on teste le service avec repo mocké : pas de DB
+public class ParcelServiceTest {
+    private ParcelRepository repo ;
+    private ParcelService service;
+    //remarque au lieu d'utilise @before each setuo on utilise ça
+    //@ExtendWith(MockitoExtension.class)
+    //class ParcelServiceTest {
+    //
+    //  @Mock
+    //  ParcelRepository repo;
+    //
+    //  @InjectMocks
+    //  ParcelService service;
+    //Là, Mockito crée service et injecte repo automatiquement.(plus recommandé)
+    @BeforeEach//init manuel
+    void setUp(){
+        repo=mock(ParcelRepository.class);
+        service = new ParcelService(repo);
+    }
+    @Test
+    void create_should_throw_when_reference_exists(){
+        when (repo.existsByReference("REF-012")).thenReturn(true);
+        assertThrows(DuplicateReferenceException.class,()->service.create(new CreateParcelRequest("REF-012")));
+    }
+    @Test
+    void create_should_save_and_return_response() {
+        when(repo.existsByReference("REF-013")).thenReturn(false);
+        Parcel saved = Parcel.create("REF-013");
+        when(repo.save(any(Parcel.class))).thenReturn(saved);
+        ParcelResponse res =service.create(new CreateParcelRequest("REF-013"));
+assertEquals("REF-013" , res.reference());
+assertEquals(ParcelStatus.CREATED ,res.status());
+ArgumentCaptor<Parcel> captor =ArgumentCaptor.forClass(Parcel.class);
+verify(repo).save(captor.capture());
+        assertEquals("REF-013",captor.getValue().getReference());
+    }
+    @Test
+    void changStatus_should_throw_not_found(){
+        when(repo.existsByReference("REF-014")).thenReturn(false);
+    assertThrows(ParcelNotFoundException.class,()->service.changeStatus("REF-404", ParcelStatus.IN_TRANSIT));
+    }
+    @Test
+    void changStatus_should_throw_invalid_transition() {
+        Parcel p = Parcel.create("REF-015");
+        when(repo.findByReference("REF-015")).thenReturn(Optional.of(p));
+        assertThrows(InvalidStatusTransitionException.class,
+                () -> service.changeStatus("REF-015", ParcelStatus.DELIVERED));
+    }
+    @Test
+    void changeStatus_should_update_status_when_valid() {
+        Parcel p = Parcel.create("REF-016"); // CREATED
+        when(repo.findByReference("REF-016")).thenReturn(Optional.of(p));
+
+        ParcelResponse res = service.changeStatus("REF-016", ParcelStatus.IN_TRANSIT);
+
+        assertEquals(ParcelStatus.IN_TRANSIT, res.status());
+    }
+    }
+
+


### PR DESCRIPTION
### Description :

Ajout des tests unitaires :
-ParcelDomainTest : transitions valides + transitions invalides + updateAt
-ParcelServiceTest : create (duplicate), getByReference (notfound), changeStatus (notfound/invalid/ok)
-Ajout des tests d’intégration :
ParcelControllerIT : endpoints REST (GET by reference, PATCH status), gestion 404/400
Vérification du comportement métier :
refus des transitions invalides (400)
colis introuvable (404)

### How to test
-mvn test